### PR TITLE
Do not send back a redirect for XHR requests

### DIFF
--- a/lib/umn_shib_auth/controller_methods.rb
+++ b/lib/umn_shib_auth/controller_methods.rb
@@ -64,9 +64,13 @@ module UmnShibAuth
     def shib_umn_auth_required
       return true if UmnShibAuth.using_stub_internet_id?
       if shib_umn_session.nil?
-        redirect_to shib_login_and_redirect_url and return false
+        if request.xml_http_request?
+          render js: "window.location.replace('#{shib_login_and_redirect_url}');" and return false
+        else
+          redirect_to shib_login_and_redirect_url and return false
+        end
       else
-        return true
+        true
       end
     end
 


### PR DESCRIPTION
Fixes https://github.umn.edu/asrweb/umn_shib_auth/issues/16

If a user makes an Ajax request after their Shib session has timed out,
they get no visual indication. It looks like the app has stopped
responding. This is because we're sending back a 302 Redirect.

Ajax libraries will follow a redirect if we send it, but it eventually
dead-ends after loading the Shib login page. We can't easily capture
this execution path in the Ajax library, either, as the browser reports
that the Ajax request was a success.

So, for XHR requests we're now sending back javascript that should be
executed by the Ajax library. This JS changes the window location to be
the Shib login page. This is _not_ a redirect, so it doesn't fall into
the same problems that the previous approach did.

For non-XHR requests, the current behavior is unchanged.