### PR TITLE
Change behavior of xhr redirect to use root_path

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,8 @@ Add a reference to umn_shib_auth in your Gemfile:
 
 Usage
 =====
+In your routes, define a [root route](http://guides.rubyonrails.org/routing.html#using-root)
+
 In application_controller.rb:
 
     include UmnShibAuth::ControllerMethods
@@ -22,6 +24,23 @@ In your views:
 In your controller:
 
     before_filter :shib_umn_auth_required
+
+Behavior
+=====
+
+If an un-authenticated user makes a request, they will be redirected (status code 302) to 
+
+    https://yourapp.umn.edu/Shibboleth.sso/Login?target=https://yourapp.umn.edu/whatever_url_they_requested
+
+If the request is an Ajax/XHR request (as defined by Rails' [`xml_http_request?`](http://api.rubyonrails.org/classes/ActionDispatch/Request.html#method-i-xml_http_request-3F) method), then the behavior is slightly different. Instead of a 302 Redirect, the user will receive some javascript that changes their browser location to
+
+    https://yourapp.umn.edu/Shibboleth.sso/Login?target=https://yourapp.umn.edu/your_root_route
+
+The behavior of the gem differs because the behavior of these two requests is not the same. 
+
+In the case of a non-XHR request, shib will redirect the user to their originally-requested URL. This is fine, as that request was already a normal HTTP request and should work as expected.
+
+But in the case of an XHR request we can not redirect the user to the same URL again. It will not behave the same because the redirect will be missing the "XMLHttpRequest" header that Rails relies on.
 
 Proxied HTTP headers
 --------------------

--- a/lib/umn_shib_auth/controller_methods.rb
+++ b/lib/umn_shib_auth/controller_methods.rb
@@ -65,7 +65,7 @@ module UmnShibAuth
       return true if UmnShibAuth.using_stub_internet_id?
       if shib_umn_session.nil?
         if request.xml_http_request?
-          render js: "window.location.replace('#{shib_login_and_redirect_url}');" and return false
+          render js: "window.location.replace('#{shib_login_and_redirect_url(root_path)}');" and return false
         else
           redirect_to shib_login_and_redirect_url and return false
         end

--- a/lib/umn_shib_auth/version.rb
+++ b/lib/umn_shib_auth/version.rb
@@ -1,3 +1,3 @@
 module UmnShibAuth
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/lib/umn_shib_auth/controller_methods_spec.rb
+++ b/spec/lib/umn_shib_auth/controller_methods_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe UmnShibAuth::ControllerMethods do
           allow(request_double).to receive(:host).and_return("secret.umn.edu")
           allow(request_double).to receive(:env).and_return({})
           allow(controller).to receive(:request).and_return(request_double)
-          @login_url = "https://secret.umn.edu/Shibboleth.sso/Login?target=#{ERB::Util.url_encode('https://google.com')}"
         end
 
         context "and the request is not an ajax request" do
           before do
             allow(request_double).to receive(:xml_http_request?).and_return(false)
+            @login_url = "https://secret.umn.edu/Shibboleth.sso/Login?target=#{ERB::Util.url_encode('https://google.com')}"
           end
 
           it "redirects and returns false" do
@@ -89,6 +89,8 @@ RSpec.describe UmnShibAuth::ControllerMethods do
         context "and the request is an ajax request" do
           before do
             allow(request_double).to receive(:xml_http_request?).and_return(true)
+            expect(controller).to receive(:root_path).and_return("https://app.umn.edu")
+            @login_url = "https://secret.umn.edu/Shibboleth.sso/Login?target=#{ERB::Util.url_encode('https://app.umn.edu')}"
           end
 
           it "renders javascript that will change the window location to the correct shib login" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,10 @@ end
 
 class DummyController < ActionController::Base
   include UmnShibAuth::ControllerMethods
+
+  # In a real Rails app that has a root route defined, this method exists
+  # But in our test setup, we don't have have this part of Rails configured.
+  # Rspec won't let us double a method that doesn't exist
+  # So we make this method exist just for our test controller
+  def root_path; end
 end


### PR DESCRIPTION
The reason for this change is covered in the addition I made to the
readme.

> In the case of a non-XHR request, shib will redirect the user to their
originally-requested URL. This is fine, as that request was already a
normal HTTP request and should work as expected.

> But in the case of an XHR request we can not redirect the user to the
same URL again. It will not behave the same because the redirect will be
missing the "XMLHttpRequest" header that Rails relies on.

The pre-change code would redirect the user to the modal route, Rails
would see it as an HTML (not JS) request and then render the response as
HTML. Which leads to weirdness.

Sending the user to the Login page & then back to Root seems to be the
path of least surprise here.